### PR TITLE
Make some basic improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 
     //optional dependency!
     modCompile "net.fabricmc.fabric-api:fabric-api:${fabric_version}"
+    testCompile "org.junit.jupiter:junit-jupiter-api:5.5.0-M1"
 }
 
 task apiJar(type: Jar, dependsOn: classes) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Fri May 17 12:49:26 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip

--- a/src/main/java/com/github/glasspane/mesh/api/annotation/FieldsAreNonnullByDefault.java
+++ b/src/main/java/com/github/glasspane/mesh/api/annotation/FieldsAreNonnullByDefault.java
@@ -19,10 +19,7 @@ package com.github.glasspane.mesh.api.annotation;
 
 import javax.annotation.Nonnull;
 import javax.annotation.meta.TypeQualifierDefault;
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.*;
 
 /**
  * This annotation can be applied to a package, class or field to indicate that
@@ -38,4 +35,5 @@ import java.lang.annotation.RetentionPolicy;
 @Nonnull
 @TypeQualifierDefault(ElementType.FIELD) // Note: This is a copy of javax.annotation.ParametersAreNonnullByDefault with target changed to FIELD
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PACKAGE, ElementType.TYPE})
 public @interface FieldsAreNonnullByDefault {}

--- a/src/main/java/com/github/glasspane/mesh/api/annotation/FieldsAreNonnullByDefault.java
+++ b/src/main/java/com/github/glasspane/mesh/api/annotation/FieldsAreNonnullByDefault.java
@@ -1,0 +1,41 @@
+/*
+ * Mesh
+ * Copyright (C) 2019 GlassPane
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; If not, see <https://www.gnu.org/licenses>.
+ */
+package com.github.glasspane.mesh.api.annotation;
+
+import javax.annotation.Nonnull;
+import javax.annotation.meta.TypeQualifierDefault;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * This annotation can be applied to a package, class or field to indicate that
+ * the fields in that element are nonnull by default unless there is:
+ * <ul>
+ * <li>An explicit nullness annotation
+ * <li>a default parameter annotation applied to a more tightly nested
+ * element.
+ * </ul>
+ *
+ */
+@Documented
+@Nonnull
+@TypeQualifierDefault(ElementType.FIELD) // Note: This is a copy of javax.annotation.ParametersAreNonnullByDefault with target changed to FIELD
+@Retention(RetentionPolicy.RUNTIME)
+public @interface FieldsAreNonnullByDefault {}

--- a/src/main/java/com/github/glasspane/mesh/api/annotation/MethodsReturnNonnullByDefault.java
+++ b/src/main/java/com/github/glasspane/mesh/api/annotation/MethodsReturnNonnullByDefault.java
@@ -19,10 +19,7 @@ package com.github.glasspane.mesh.api.annotation;
 
 import javax.annotation.Nonnull;
 import javax.annotation.meta.TypeQualifierDefault;
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.*;
 
 /**
  * This annotation can be applied to a package, class or method to indicate that
@@ -40,4 +37,5 @@ import java.lang.annotation.RetentionPolicy;
 @Nonnull
 @TypeQualifierDefault(ElementType.METHOD) // Note: This is a copy of javax.annotation.ParametersAreNonnullByDefault with target changed to METHOD
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PACKAGE, ElementType.TYPE})
 public @interface MethodsReturnNonnullByDefault {}

--- a/src/main/java/com/github/glasspane/mesh/api/annotation/MethodsReturnNonnullByDefault.java
+++ b/src/main/java/com/github/glasspane/mesh/api/annotation/MethodsReturnNonnullByDefault.java
@@ -1,0 +1,43 @@
+/*
+ * Mesh
+ * Copyright (C) 2019 GlassPane
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; If not, see <https://www.gnu.org/licenses>.
+ */
+package com.github.glasspane.mesh.api.annotation;
+
+import javax.annotation.Nonnull;
+import javax.annotation.meta.TypeQualifierDefault;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * This annotation can be applied to a package, class or method to indicate that
+ * the method in that element are nonnull by default unless there is:
+ * <ul>
+ * <li>An explicit nullness annotation
+ * <li>The method overrides a method in a superclass (in which case the
+ * annotation of the corresponding method in the superclass applies)
+ * <li> there is a default parameter annotation applied to a more tightly nested
+ * element.
+ * </ul>
+ *
+ */
+@Documented
+@Nonnull
+@TypeQualifierDefault(ElementType.METHOD) // Note: This is a copy of javax.annotation.ParametersAreNonnullByDefault with target changed to METHOD
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MethodsReturnNonnullByDefault {}

--- a/src/main/java/com/github/glasspane/mesh/api/annotation/Unlocalized.java
+++ b/src/main/java/com/github/glasspane/mesh/api/annotation/Unlocalized.java
@@ -1,0 +1,42 @@
+/*
+ * Mesh
+ * Copyright (C) 2019 GlassPane
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; If not, see <https://www.gnu.org/licenses>.
+ */
+package com.github.glasspane.mesh.api.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that a String should be used as a translation key
+ * <p>
+ *     Example:
+ *     <pre><code>
+ *         List&lt;@Unlocalized String&gt lines = obj.getLines();
+ *         for (@Unlocalized String line : lines) {
+ *             font.drawString(I18n.translate(line), 0, 0, 0xFFFFFF);
+ *         }
+ *     </code></pre>
+ * </p>
+ * @see net.minecraft.client.resource.language.I18n
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE_USE})
+public @interface Unlocalized {
+
+}

--- a/src/main/java/com/github/glasspane/mesh/api/util/LazyReference.java
+++ b/src/main/java/com/github/glasspane/mesh/api/util/LazyReference.java
@@ -15,21 +15,23 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; If not, see <https://www.gnu.org/licenses>.
  */
-package com.github.glasspane.mesh.api.objects;
+package com.github.glasspane.mesh.api.util;
 
+import net.minecraft.util.Lazy;
 import org.apache.commons.lang3.Validate;
 
 import javax.annotation.Nullable;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-public class LazyReference<T> implements Supplier<T> {
-
-    private Supplier<T> getter;
-    private T object = null;
+/**
+ * An improved {@link Lazy} that doubles as a {@link Supplier}
+ * @param <T> the type of value held by this reference
+ */
+public class LazyReference<T> extends Lazy<T> implements Supplier<T> {
 
     public LazyReference(Supplier<T> getter) {
-        this.getter = Validate.notNull(getter, "Supplier must not be NULL");
+        super(Validate.notNull(getter, "Supplier must not be NULL"));
     }
 
     @Override
@@ -40,16 +42,14 @@ public class LazyReference<T> implements Supplier<T> {
     @Nullable
     @Override
     public T get() {
-        if(this.getter != null) {
-            this.object = getter.get();
-            this.getter = null;
-        }
-        return this.object;
+        // Override to work with obfuscation
+        return super.get();
     }
 
     public void ifPresent(Consumer<T> action) {
-        if(this.get() != null) {
-            action.accept(this.object);
+        T value = this.get();
+        if(value != null) {
+            action.accept(value);
         }
     }
 }

--- a/src/main/java/com/github/glasspane/mesh/impl/crafting/recipe/Recipe.java
+++ b/src/main/java/com/github/glasspane/mesh/impl/crafting/recipe/Recipe.java
@@ -17,7 +17,7 @@
  */
 package com.github.glasspane.mesh.impl.crafting.recipe;
 
-import com.github.glasspane.mesh.api.objects.LazyReference;
+import com.github.glasspane.mesh.api.util.LazyReference;
 import com.google.gson.annotations.SerializedName;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Identifier;

--- a/src/main/java/com/github/glasspane/mesh/impl/serialization/IdentifierAdapter.java
+++ b/src/main/java/com/github/glasspane/mesh/impl/serialization/IdentifierAdapter.java
@@ -33,6 +33,6 @@ public class IdentifierAdapter extends TypeAdapter<Identifier> {
 
     @Override
     public Identifier read(JsonReader in) throws IOException {
-        return Identifier.create(in.nextString());
+        return Identifier.ofNullable(in.nextString());
     }
 }

--- a/src/main/java/com/github/glasspane/mesh/impl/serialization/IdentifierAdapter.java
+++ b/src/main/java/com/github/glasspane/mesh/impl/serialization/IdentifierAdapter.java
@@ -18,19 +18,21 @@
 package com.github.glasspane.mesh.impl.serialization;
 
 import com.google.gson.*;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import net.minecraft.util.Identifier;
 
+import java.io.IOException;
 import java.lang.reflect.Type;
 
-public class IdentifierJsonSerializer implements JsonSerializer<Identifier>, JsonDeserializer<Identifier> {
-
+public class IdentifierAdapter extends TypeAdapter<Identifier> {
     @Override
-    public Identifier deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
-        return new Identifier(json.getAsString());
+    public void write(JsonWriter out, Identifier value) throws IOException {
+        out.value(value.toString());
     }
 
     @Override
-    public JsonElement serialize(Identifier src, Type typeOfSrc, JsonSerializationContext context) {
-        return new JsonPrimitive(String.valueOf(src.toString()));
+    public Identifier read(JsonReader in) throws IOException {
+        return Identifier.create(in.nextString());
     }
 }

--- a/src/main/java/com/github/glasspane/mesh/impl/serialization/ItemStackJsonSerializer.java
+++ b/src/main/java/com/github/glasspane/mesh/impl/serialization/ItemStackJsonSerializer.java
@@ -19,7 +19,7 @@ package com.github.glasspane.mesh.impl.serialization;
 
 import com.google.gson.*;
 import net.minecraft.item.ItemStack;
-import net.minecraft.recipe.crafting.ShapedRecipe;
+import net.minecraft.recipe.ShapedRecipe;
 import net.minecraft.util.registry.Registry;
 
 import java.lang.reflect.Type;

--- a/src/main/java/com/github/glasspane/mesh/impl/serialization/ItemStackJsonSerializer.java
+++ b/src/main/java/com/github/glasspane/mesh/impl/serialization/ItemStackJsonSerializer.java
@@ -17,15 +17,9 @@
  */
 package com.github.glasspane.mesh.impl.serialization;
 
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.google.gson.JsonSerializationContext;
-import com.google.gson.JsonSerializer;
+import com.google.gson.*;
 import net.minecraft.item.ItemStack;
-import net.minecraft.recipe.ShapedRecipe;
+import net.minecraft.recipe.crafting.ShapedRecipe;
 import net.minecraft.util.registry.Registry;
 
 import java.lang.reflect.Type;

--- a/src/main/java/com/github/glasspane/mesh/impl/serialization/RegistryValueAdapter.java
+++ b/src/main/java/com/github/glasspane/mesh/impl/serialization/RegistryValueAdapter.java
@@ -20,7 +20,6 @@ package com.github.glasspane.mesh.impl.serialization;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
-import net.minecraft.entity.EntityType;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 
@@ -45,6 +44,6 @@ public class RegistryValueAdapter<T> extends TypeAdapter<T> {
 
     @Override
     public T read(JsonReader in) throws IOException {
-        return registry.get(Identifier.create(in.nextString()));
+        return registry.get(Identifier.ofNullable(in.nextString()));
     }
 }

--- a/src/main/java/com/github/glasspane/mesh/impl/serialization/RegistryValueAdapter.java
+++ b/src/main/java/com/github/glasspane/mesh/impl/serialization/RegistryValueAdapter.java
@@ -1,0 +1,33 @@
+package com.github.glasspane.mesh.impl.serialization;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import net.minecraft.entity.EntityType;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * A generic {@link TypeAdapter} for values of a registry
+ * @param <T> the type of the registry
+ */
+public class RegistryValueAdapter<T> extends TypeAdapter<T> {
+    private final Registry<T> registry;
+
+    public RegistryValueAdapter(Registry<T> registry) {
+        this.registry = registry;
+    }
+
+    @Override
+    public void write(JsonWriter out, T value) throws IOException {
+        out.value(Objects.requireNonNull(registry.getId(value)).toString());
+    }
+
+    @Override
+    public T read(JsonReader in) throws IOException {
+        return registry.get(Identifier.create(in.nextString()));
+    }
+}

--- a/src/main/java/com/github/glasspane/mesh/impl/serialization/RegistryValueAdapter.java
+++ b/src/main/java/com/github/glasspane/mesh/impl/serialization/RegistryValueAdapter.java
@@ -1,3 +1,20 @@
+/*
+ * Mesh
+ * Copyright (C) 2019 GlassPane
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; If not, see <https://www.gnu.org/licenses>.
+ */
 package com.github.glasspane.mesh.impl.serialization;
 
 import com.google.gson.TypeAdapter;

--- a/src/main/java/com/github/glasspane/mesh/util/JsonUtil.java
+++ b/src/main/java/com/github/glasspane/mesh/util/JsonUtil.java
@@ -17,14 +17,14 @@
  */
 package com.github.glasspane.mesh.util;
 
-import com.github.glasspane.mesh.impl.serialization.IdentifierJsonSerializer;
-import com.github.glasspane.mesh.impl.serialization.IngredientJsonSerializer;
-import com.github.glasspane.mesh.impl.serialization.ItemStackJsonSerializer;
+import com.github.glasspane.mesh.impl.serialization.*;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.recipe.Ingredient;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
 
 public class JsonUtil {
 
@@ -32,7 +32,8 @@ public class JsonUtil {
     public static final Gson GSON = new GsonBuilder()
             .setPrettyPrinting()
             .disableHtmlEscaping()
-            .registerTypeAdapter(Identifier.class, new IdentifierJsonSerializer())
+            .registerTypeAdapter(Identifier.class, new IdentifierAdapter())
+            .registerTypeAdapter(Item.class, new RegistryValueAdapter<>(Registry.ITEM))
             .registerTypeAdapter(ItemStack.class, new ItemStackJsonSerializer())
             .registerTypeAdapter(Ingredient.class, new IngredientJsonSerializer())
             .create();

--- a/src/main/java/com/github/glasspane/mesh/util/JsonUtil.java
+++ b/src/main/java/com/github/glasspane/mesh/util/JsonUtil.java
@@ -17,7 +17,7 @@
  */
 package com.github.glasspane.mesh.util;
 
-import com.github.glasspane.mesh.impl.serialization.IdentifierJsonSerializer;
+import com.github.glasspane.mesh.impl.serialization.IdentifierAdapter;
 import com.github.glasspane.mesh.impl.serialization.IngredientJsonSerializer;
 import com.github.glasspane.mesh.impl.serialization.ItemStackJsonSerializer;
 import com.google.gson.Gson;
@@ -34,7 +34,7 @@ public class JsonUtil {
         GsonBuilder builder = new GsonBuilder();
         builder.setPrettyPrinting();
         builder.disableHtmlEscaping();
-        builder.registerTypeAdapter(Identifier.class, new IdentifierJsonSerializer());
+        builder.registerTypeAdapter(Identifier.class, new IdentifierAdapter());
         builder.registerTypeAdapter(ItemStack.class, new ItemStackJsonSerializer());
         builder.registerTypeAdapter(Ingredient.class, new IngredientJsonSerializer());
         //TODO register type adapters here

--- a/src/test/java/com/github/glasspane/mesh/util/JsonUtilTest.java
+++ b/src/test/java/com/github/glasspane/mesh/util/JsonUtilTest.java
@@ -1,0 +1,18 @@
+package com.github.glasspane.mesh.util;
+
+import net.minecraft.util.Identifier;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JsonUtilTest {
+    @Test
+    void identifiersSerialize() {
+        assertEquals("\"mesh:test\"", JsonUtil.GSON.toJson(new Identifier("mesh", "test")));
+    }
+
+    @Test
+    void identifiersDeserialize() {
+        assertEquals(new Identifier("hi"), JsonUtil.GSON.fromJson("\"minecraft:hi\"", Identifier.class));
+    }
+}


### PR DESCRIPTION
This PR adds a few source annotations that I find myself using quite often (in `package-info` notably). It also adds a type adapter for any registry value. As type adapters are to be preferred to json serializers (see the latter's javadoc), the identifier serializer has also been made into a type adapter.
`LazyReference` has been made a subclass of `net.minecraft.util.Lazy`, as it was already duplicated code. This allows it to be used both as a Lazy and a Supplier.
Finally, the `api.objects` package has been renamed to `api.util`. The reasoning is that `objects` is non-conventional package name (plural) that is not very descriptive and is unlikely to host many appropriate classes.